### PR TITLE
Log late API requests instead of throwing exceptions

### DIFF
--- a/AssetHelper/AssetHelper.csproj
+++ b/AssetHelper/AssetHelper.csproj
@@ -79,7 +79,7 @@
     -->
     <AssetHelperLibDevelopment>false</AssetHelperLibDevelopment>
     <AssetHelperLibFolder>../../AssetHelperLib/AssetHelperLib/bin/Debug/netstandard2.1</AssetHelperLibFolder>
-    <Version>1.3.2</Version>
+    <Version>1.3.1</Version>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(AssetHelperLibDevelopment)' == 'false'">

--- a/AssetHelper/AssetHelper.csproj
+++ b/AssetHelper/AssetHelper.csproj
@@ -79,7 +79,6 @@
     -->
     <AssetHelperLibDevelopment>false</AssetHelperLibDevelopment>
     <AssetHelperLibFolder>../../AssetHelperLib/AssetHelperLib/bin/Debug/netstandard2.1</AssetHelperLibFolder>
-    <Version>1.3.1</Version>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(AssetHelperLibDevelopment)' == 'false'">

--- a/AssetHelper/AssetHelper.csproj
+++ b/AssetHelper/AssetHelper.csproj
@@ -79,6 +79,7 @@
     -->
     <AssetHelperLibDevelopment>false</AssetHelperLibDevelopment>
     <AssetHelperLibFolder>../../AssetHelperLib/AssetHelperLib/bin/Debug/netstandard2.1</AssetHelperLibFolder>
+    <Version>1.3.2</Version>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(AssetHelperLibDevelopment)' == 'false'">

--- a/AssetHelper/ManagedAssets/ManagedAsset.cs
+++ b/AssetHelper/ManagedAssets/ManagedAsset.cs
@@ -79,7 +79,8 @@ public class ManagedAsset<T>(string key) : ManagedAssetBase<T>
         }
         else
         {
-            if (!string.IsNullOrEmpty(bundleName)) { 
+            if (!string.IsNullOrEmpty(bundleName)) 
+            { 
                 if (!AssetRequestAPI.Request.NonSceneAssets.TryGetValue((bundleName, assetName), out Type _))
                 {
                     AssetHelperPlugin.InstanceLogger.LogWarning(

--- a/AssetHelper/ManagedAssets/ManagedAsset.cs
+++ b/AssetHelper/ManagedAssets/ManagedAsset.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Silksong.AssetHelper.Plugin;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -76,8 +77,21 @@ public class ManagedAsset<T>(string key) : ManagedAssetBase<T>
         {
             AssetRequestAPI.RequestNonSceneAsset<T>(bundleName, assetName);
         }
-        // TODO - include log message if this is constructed too late and the key isn't in the request;
-        // this requires more complex normalization so I am skipping for now
+        else
+        {
+            if (!string.IsNullOrEmpty(bundleName)) { 
+                if (!AssetRequestAPI.Request.NonSceneAssets.TryGetValue((bundleName, assetName), out Type _))
+                {
+                    AssetHelperPlugin.InstanceLogger.LogWarning(
+                        $"Constructing managed asset from non-scene bundle {bundleName}, {assetName} after Awake may not work unless the asset has been requested first!");
+                }
+            } 
+            else
+            {
+                AssetHelperPlugin.InstanceLogger.LogWarning(
+                    $"Constructing managed asset {assetName} from non-scene bundle will not work if the bundle name is not provided or the asset has not been previously requested!");
+            }
+        }
 
         string key = CatalogKeys.GetKeyForNonSceneAsset(assetName);
         return new(key);

--- a/AssetHelper/ManagedAssets/ManagedAsset.cs
+++ b/AssetHelper/ManagedAssets/ManagedAsset.cs
@@ -81,17 +81,16 @@ public class ManagedAsset<T>(string key) : ManagedAssetBase<T>
         {
             if (!string.IsNullOrEmpty(bundleName)) 
             { 
-                if (!AssetRequestAPI.Request.NonSceneAssets.TryGetValue((bundleName, assetName), out Type _))
+                if (!AssetRequestAPI.Request.NonSceneAssets.ContainsKey((bundleName, assetName)))
                 {
                     AssetHelperPlugin.InstanceLogger.LogWarning(
-                        $"Constructing managed asset from non-scene bundle {bundleName}, {assetName} after Awake may not work unless the asset has been requested first!");
+                        $"Constructing managed asset {assetName} from non-scene bundle {bundleName} after Awake may not work unless the asset has been requested first!");
                 }
             } 
-            else
-            {
-                AssetHelperPlugin.InstanceLogger.LogWarning(
-                    $"Constructing managed asset {assetName} from non-scene bundle will not work if the bundle name is not provided or the asset has not been previously requested!");
-            }
+
+            // Other cases are not logged as it could lead to false positives.
+            // Ensure the bundleName is included in the request if you want its assets catalogued
+
         }
 
         string key = CatalogKeys.GetKeyForNonSceneAsset(assetName);

--- a/AssetHelper/ManagedAssets/ManagedAssetGroup.cs
+++ b/AssetHelper/ManagedAssets/ManagedAssetGroup.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿using HutongGames.PlayMaker.Actions;
+using Silksong.AssetHelper.Plugin;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Silksong.AssetHelper.Plugin;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;
@@ -104,7 +105,7 @@ public class ManagedAssetGroup<T> : IManagedAsset
                     if (!AssetRequestAPI.Request.NonSceneAssets.ContainsKey((asset.BundleName, asset.AssetName)))
                     {
                         AssetHelperPlugin.InstanceLogger.LogWarning(
-                            $"Constructing managed asset from non-scene bundle {asset.BundleName}, {asset.AssetName} after Awake may not work unless the asset has been requested first!");
+                            $"Constructing managed asset {asset.AssetName} from non-scene bundle {asset.BundleName} after Awake may not work unless the asset has been requested first!");
                     }
                 }
 

--- a/AssetHelper/ManagedAssets/ManagedAssetGroup.cs
+++ b/AssetHelper/ManagedAssets/ManagedAssetGroup.cs
@@ -1,5 +1,4 @@
-﻿using HutongGames.PlayMaker.Actions;
-using Silksong.AssetHelper.Plugin;
+﻿using Silksong.AssetHelper.Plugin;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/AssetHelper/ManagedAssets/ManagedAssetGroup.cs
+++ b/AssetHelper/ManagedAssets/ManagedAssetGroup.cs
@@ -55,12 +55,6 @@ public class ManagedAssetGroup<T> : IManagedAsset
         Dictionary<string, NonSceneAssetInfo>? nonSceneAssets = null
     )
     {
-        if (!AssetRequestAPI.RequestApiAvailable)
-        {
-            throw new InvalidOperationException(
-                "Asset requests should be made during or before a plugin's Awake method!"
-            );
-        }
 
         Dictionary<string, string> keyLookup = [];
 
@@ -75,7 +69,21 @@ public class ManagedAssetGroup<T> : IManagedAsset
 
             foreach ((string name, SceneAssetInfo asset) in sceneAssets)
             {
-                AssetRequestAPI.RequestSceneAsset(asset.SceneName, asset.ObjPath);
+                
+                if (AssetRequestAPI.RequestApiAvailable)
+                {
+                    AssetRequestAPI.RequestSceneAsset(asset.SceneName, asset.ObjPath);
+                } 
+                else
+                {
+                    if (!AssetRequestAPI.Request.SceneAssets.TryGetValue(asset.SceneName.ToLowerInvariant(), out HashSet<string> objNames)
+                        || !objNames.Contains(asset.ObjPath))
+                    {
+                        AssetHelperPlugin.InstanceLogger.LogWarning(
+                            $"Constructing managed asset from scene {asset.SceneName}, {asset.ObjPath} after Awake may not work unless the asset has been requested first!");
+                    }
+                }       
+
                 keyLookup.Add(
                     name,
                     CatalogKeys.GetKeyForSceneAsset(asset.SceneName, asset.ObjPath)
@@ -87,7 +95,20 @@ public class ManagedAssetGroup<T> : IManagedAsset
         {
             foreach ((string name, NonSceneAssetInfo asset) in nonSceneAssets)
             {
-                AssetRequestAPI.RequestNonSceneAsset<T>(asset.BundleName, asset.AssetName);
+
+                if (AssetRequestAPI.RequestApiAvailable)
+                {
+                    AssetRequestAPI.RequestNonSceneAsset<T>(asset.BundleName, asset.AssetName);
+                }
+                else
+                {
+                    if (!AssetRequestAPI.Request.NonSceneAssets.TryGetValue((asset.BundleName, asset.AssetName), out Type _))
+                    {
+                        AssetHelperPlugin.InstanceLogger.LogWarning(
+                            $"Constructing managed asset from non-scene bundle {asset.BundleName}, {asset.AssetName} after Awake may not work unless the asset has been requested first!");
+                    }
+                }
+
                 keyLookup.Add(name, CatalogKeys.GetKeyForNonSceneAsset(asset.AssetName));
             }
         }

--- a/AssetHelper/ManagedAssets/ManagedAssetGroup.cs
+++ b/AssetHelper/ManagedAssets/ManagedAssetGroup.cs
@@ -95,7 +95,6 @@ public class ManagedAssetGroup<T> : IManagedAsset
         {
             foreach ((string name, NonSceneAssetInfo asset) in nonSceneAssets)
             {
-
                 if (AssetRequestAPI.RequestApiAvailable)
                 {
                     AssetRequestAPI.RequestNonSceneAsset<T>(asset.BundleName, asset.AssetName);

--- a/AssetHelper/ManagedAssets/ManagedAssetGroup.cs
+++ b/AssetHelper/ManagedAssets/ManagedAssetGroup.cs
@@ -101,7 +101,7 @@ public class ManagedAssetGroup<T> : IManagedAsset
                 }
                 else
                 {
-                    if (!AssetRequestAPI.Request.NonSceneAssets.TryGetValue((asset.BundleName, asset.AssetName), out Type _))
+                    if (!AssetRequestAPI.Request.NonSceneAssets.ContainsKey((asset.BundleName, asset.AssetName)))
                     {
                         AssetHelperPlugin.InstanceLogger.LogWarning(
                             $"Constructing managed asset from non-scene bundle {asset.BundleName}, {asset.AssetName} after Awake may not work unless the asset has been requested first!");

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
     It should follow the format major.minor.patch (semantic versioning). If you publish your mod
     as a library to NuGet, this version will also be used as the package version.
     -->
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Summary of Changes

Provide a quick summary of the change. What problem is being addressed and how?

- Edited `ManagedAssetGroup.RequestAndCreate` function to log a warning for late API requests (outside of the plugin Awake) instead of throwing an exception and allow the ManagedAssetGroup to be created.
- Added a warning to `ManagedAsset.FromNonSceneAsset` for late API requests or if the bundle name is not provided

### Checklist

* No change is too small for a release, so pick one:
  * [x] I have updated the package version following semantic versioning
  * [ ] There is another change actively WIP that will update the version (link issue or PR here)
  * [ ] This PR does not update user-facing code/config
  * [ ] I'm not sure how to set the version and would like the reviewer's help
  
